### PR TITLE
Getters added in FlDrawController

### DIFF
--- a/lib/src/core/controller/fldraw_controller.dart
+++ b/lib/src/core/controller/fldraw_controller.dart
@@ -111,6 +111,48 @@ class FlDrawControllerImpl implements FlDrawController {
     return _toolBloc!.state;
   }
 
+  /// Gets the list of all [NodeInstance]s currently in the canvas.
+  @override
+  Map<String, NodeInstance> get nodes {
+    _assertIsInitialized();
+    return canvasState.nodes;
+  }
+
+  /// Gets the list of all [DrawingObject]s currently in the canvas.
+  @override
+  Map<String, DrawingObject> get drawingObjects {
+    _assertIsInitialized();
+    return canvasState.drawingObjects;
+  }
+
+  /// Gets the current viewport offset.
+  @override
+  Offset get viewportOffset {
+    _assertIsInitialized();
+    return canvasState.viewportOffset;
+  }
+
+  /// Gets the current viewport zoom level.
+  @override
+  double get viewportZoom {
+    _assertIsInitialized();
+    return canvasState.viewportZoom;
+  }
+
+  /// Gets the undo history stack.
+  @override
+  List<HistoryEntry> get undoStack {
+    _assertIsInitialized();
+    return canvasState.undoStack;
+  }
+
+  /// Gets the redo history stack.
+  @override
+  List<HistoryEntry> get redoStack {
+    _assertIsInitialized();
+    return canvasState.redoStack;
+  }
+
   // --- Tool Methods ---
 
   /// Sets the active drawing tool.

--- a/lib/src/core/controller/fldraw_controller_interface.dart
+++ b/lib/src/core/controller/fldraw_controller_interface.dart
@@ -16,6 +16,18 @@ abstract class FlDrawController {
 
   ToolState get toolState;
 
+  Map<String, NodeInstance> get nodes;
+
+  Map<String, DrawingObject> get drawingObjects;
+
+  Offset get viewportOffset;
+
+  double get viewportZoom;
+
+  List<HistoryEntry> get undoStack;
+
+  List<HistoryEntry> get redoStack;
+
   // --- Tool Methods ---
 
   void setTool(EditorTool tool);


### PR DESCRIPTION
Added additional getters to FlDrawController

nodes, drawingObjects, viewportOffset, viewportZoom, undoStack, redoStack